### PR TITLE
Option to include More Distribution

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ monte_carlo:
       generators_t.p_max_pu.loc[:, network.generators.carrier == "solar"]: [0.5, 2]
       # ... user can add here flexibly more features for the Monte-Carlo sampling
     options:
-      distribution: "normal" # "uniform", "normal"
-      samples: 9  # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+      distribution: "Normal" # "Uniform", "Normal", "LogNormal"
+      samples: 9 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
       sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,6 @@ monte_carlo:
       # TODO: Support inputs to simulate outages of biggest power plant "generators.p_nom.max()": [-1000MW 0MW]
       loads_t.p_set: [0.9, 1.1]
       generators_t.p_max_pu.loc[:, network.generators.carrier == "wind"]: [0.5, 1.2]
-      lines.capital_cost: [0.5, 1.5]
       # ... user can add here flexibly more features for the Monte-Carlo sampling
     options:
       # Uniform: https://chaospy.readthedocs.io/en/master/api/chaospy.Uniform.html
@@ -26,7 +25,7 @@ monte_carlo:
       # [lower_bound, midpoint, upper_bound] for Triangle 
       # [alpha, beta] for Beta
       # [shape, scale] for Gamma
-      distribution_params: [0, 1] 
-      samples: 16 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+      distribution_params: [0, 1]
+      samples: 9 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
       sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ monte_carlo:
       # TODO: Support inputs to simulate outages of biggest power plant "generators.p_nom.max()": [-1000MW 0MW]
       loads_t.p_set: [0.9, 1.1]
       generators_t.p_max_pu.loc[:, network.generators.carrier == "wind"]: [0.5, 1.2]
-      generators_t.p_max_pu.loc[:, network.generators.carrier == "solar"]: [0.5, 2]
+      lines.capital_cost: [0.5, 1.5]
       # ... user can add here flexibly more features for the Monte-Carlo sampling
     options:
       # Uniform: https://chaospy.readthedocs.io/en/master/api/chaospy.Uniform.html
@@ -20,13 +20,13 @@ monte_carlo:
       # Triange: https://chaospy.readthedocs.io/en/master/api/chaospy.Triangle.html
       # Beta: https://chaospy.readthedocs.io/en/master/api/chaospy.Beta.html
       # Gamma: https://chaospy.readthedocs.io/en/master/api/chaospy.Gamma.html
-      distribution: "Triangle" # "Uniform", "Normal", "LogNormal", "Triangle", "Beta", "Gamma
+      distribution: "Normal" # "Uniform", "Normal", "LogNormal", "Triangle", "Beta", "Gamma"
       # [mean, std] for Normal and LogNormal
       # [lower_bound, upper_bound] for Uniform
       # [lower_bound, midpoint, upper_bound] for Triangle 
       # [alpha, beta] for Beta
       # [shape, scale] for Gamma
-      distribution_params: [0, 0.5, 1] 
-      samples: 150 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+      distribution_params: [0, 1] 
+      samples: 16 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
       sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
 

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,19 @@ monte_carlo:
       generators_t.p_max_pu.loc[:, network.generators.carrier == "solar"]: [0.5, 2]
       # ... user can add here flexibly more features for the Monte-Carlo sampling
     options:
-      distribution: "Normal" # "Uniform", "Normal", "LogNormal"
-      samples: 9 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
+      # Uniform: https://chaospy.readthedocs.io/en/master/api/chaospy.Uniform.html
+      # Normal: https://chaospy.readthedocs.io/en/master/api/chaospy.Normal.html
+      # LogNormal: https://chaospy.readthedocs.io/en/master/api/chaospy.LogNormal.html
+      # Triange: https://chaospy.readthedocs.io/en/master/api/chaospy.Triangle.html
+      # Beta: https://chaospy.readthedocs.io/en/master/api/chaospy.Beta.html
+      # Gamma: https://chaospy.readthedocs.io/en/master/api/chaospy.Gamma.html
+      distribution: "Triangle" # "Uniform", "Normal", "LogNormal", "Triangle", "Beta", "Gamma
+      # [mean, std] for Normal and LogNormal
+      # [lower_bound, upper_bound] for Uniform
+      # [lower_bound, midpoint, upper_bound] for Triangle 
+      # [alpha, beta] for Beta
+      # [shape, scale] for Gamma
+      distribution_params: [0, 0.5, 1] 
+      samples: 150 # number of optimizations. Note that number of samples when using scipy has to be the square of a prime number
       sampling_strategy: "chaospy"  # "pydoe2", "chaospy", "scipy", packages that are supported
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -52,8 +52,10 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION
     if DISTRIBUTION == "Uniform":
         pass
     elif DISTRIBUTION in ["Normal", "LogNormal", "Triangle", "Beta", "Gamma"]:
-        mm = MinMaxScaler(feature_range=(0,0.99))
+        mm = MinMaxScaler(feature_range=(0,1.))
         lh = mm.fit_transform(lh)
+        print(lh.max())
+        print(lh.min())
     else:
         raise ValueError(f"Distribution '{DISTRIBUTION}' not available. Please pick a valid one from possible options: 'Uniform', 'Normal', 'LogNormal', 'Triangle', 'Beta', 'Gamma'")
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -44,7 +44,7 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION
     from sklearn.preprocessing import MinMaxScaler
     params = tuple(DISTRIBUTION_PARAMS)
     # Generate a Nfeatures-dimensional latin hypercube varying between 0 and 1:
-    N_FEATURES = f"chaospy.{DISTRIBUTION}{tuple(params)}, "*N_FEATURES
+    N_FEATURES = f"chaospy.{DISTRIBUTION}{params}, "*N_FEATURES
     cube = eval(f"chaospy.J({N_FEATURES})")  # writes Nfeatures times the chaospy.uniform... command)
     lh = cube.sample(SAMPLES, rule=rule, seed=seed).T
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -21,7 +21,7 @@ def monte_carlo_sampling_pydoe2(N_FEATURES, SAMPLES, criterion=None, iteration=N
     Documentation on PyDOE2: https://github.com/clicumu/pyDOE2 (fixes latin_cube errors)
     """
     from pyDOE2 import lhs
-    from scipy.stats import qmc 
+    from scipy.stats import qmc
 
     # Generate a Nfeatures-dimensional latin hypercube varying between 0 and 1:
     lh = lhs(N_FEATURES, samples=SAMPLES, criterion=criterion, iterations=iteration, random_state=random_state, correlation_matrix=correlation_matrix)
@@ -40,7 +40,7 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION
 
     """
     import chaospy
-    from scipy.stats import qmc 
+    from scipy.stats import qmc
     from sklearn.preprocessing import MinMaxScaler
 
     params = tuple(DISTRIBUTION_PARAMS)
@@ -74,8 +74,8 @@ def monte_carlo_sampling_scipy(N_FEATURES, SAMPLES, centered=False, strength=2, 
     Documentation for Latin Hypercube: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.qmc.LatinHypercube.html#scipy.stats.qmc.LatinHypercube
     Orthogonal LHS is better than basic LHS: https://github.com/scipy/scipy/pull/14546/files, https://en.wikipedia.org/wiki/Latin_hypercube_sampling
     """
-    from scipy.stats import qmc    
-    
+    from scipy.stats import qmc
+
     sampler = qmc.LatinHypercube(d=N_FEATURES, centered=centered, strength=strength, optimization=optimization, seed=seed)
     lh = sampler.random(n=SAMPLES)
     discrepancy = qmc.discrepancy(lh)
@@ -84,9 +84,11 @@ def monte_carlo_sampling_scipy(N_FEATURES, SAMPLES, centered=False, strength=2, 
     return lh
 
 
-def validate_parameters(SAMPLING_STRATEGY, DISTRIBUTION, DISTRIBUTION_PARAMS):
+def validate_parameters(sampling_strategy: str, samples: int,
+                        distribution: str, distribution_params: list) -> None:
     """
     Validates the parameters for a given probability distribution.
+    Inputs from user through the config file needs to be validated before proceeding to perform monte-carlo simulations.
 
     Parameters:
     - DISTRIBUTION: str
@@ -99,38 +101,56 @@ def validate_parameters(SAMPLING_STRATEGY, DISTRIBUTION, DISTRIBUTION_PARAMS):
     """
 
     valid_strategy = ["chaospy", "scipy", "pydoe2"]
-    valid_distribution = ["Uniform", "Normal", "LogNormal", "Triangle", "Beta", "Gamma"]
+    valid_distribution = [
+        "Uniform", "Normal", "LogNormal", "Triangle", "Beta", "Gamma"
+    ]
 
-    # Check if the sampling strategy is valid
-    if SAMPLING_STRATEGY not in valid_strategy:
-        raise ValueError(f" Invalid sampling strategy: {SAMPLING_STRATEGY}")
+    # verifying samples and distribution_params
+    if samples is None:
+        raise ValueError(f"assign a value to samples")
+    elif type(samples) is float or type(samples) is str:
+        raise ValueError(f"samples must be an integer")
+    elif distribution_params is None or len(distribution_params) == 0:
+        raise ValueError(f"assign a list of parameters to distribution_params")
 
-    # Check if the specified distribution is in the list of valid distributions
-    if DISTRIBUTION not in valid_distribution:
-        raise ValueError(f"Unsupported Distribution : {DISTRIBUTION}")
+    # verify sampling strategy
+    if sampling_strategy not in valid_strategy:
+        raise ValueError(
+            f" Invalid sampling strategy: {sampling_strategy}. Choose from {valid_strategy}"
+        )
 
-    # Check special case for Triangle distribution
-    if DISTRIBUTION == "Triangle" and len(DISTRIBUTION_PARAMS) == 2:
-            print(f"{DISTRIBUTION} distribution has to be 3 parameters in the order of [lower_bound, mid_range, upper_bound]")            
-            # Calculate and insert the mean into the middle
-            DISTRIBUTION_PARAMS.insert(1, np.mean(DISTRIBUTION_PARAMS))
-    elif DISTRIBUTION == "Triangle" and len(DISTRIBUTION_PARAMS) == 3:
-        pass
-    else:
-        # Raise an error if the number of parameters is not 2 or 3
-        raise ValueError(f"{DISTRIBUTION} distribution has to be 3 parameters in the order of [lower_bound, mid_range, upper_bound]")
+    # verify distribution
+    if distribution not in valid_distribution:
+        raise ValueError(
+            f"Unsupported Distribution : {distribution}. Choose from {valid_distribution}"
+        )
 
-    # Handling having 0 as values in Beta and Gamma            
-    if DISTRIBUTION in ["Beta", "Gamma"]:
+    # Special case handling for Triangle distribution
+    if distribution == "Triangle":
+        if len(distribution_params) == 2:
+            print(
+                f"{distribution} distribution has to be 3 parameters in the order of [lower_bound, mid_range, upper_bound]"
+            )
+            # use the mean as the middle value
+            distribution_params.insert(1, np.mean(distribution_params))
+        elif len(distribution_params) != 3:
+            raise ValueError(
+                f"{distribution} distribution has to be 3 parameters in the order of [lower_bound, mid_range, upper_bound]"
+            )
+
+    # Handling having 0 as values in Beta and Gamma
+    if distribution in ["Beta", "Gamma"]:
         # Check if any parameter is less than or equal to 0
-        if np.min(DISTRIBUTION_PARAMS) <= 0:
-            raise ValueError(f"{DISTRIBUTION} distribution cannot have values lower than zero in parameters")
+        if np.min(distribution_params) <= 0:
+            raise ValueError(
+                f"{distribution} distribution cannot have values lower than zero in parameters"
+            )
 
     # Handling cases of less than or greater than 2 parameters for Normal, LogNormal, Uniform, Beta, and Gamma
-    if DISTRIBUTION in ["Normal", "LogNormal", "Uniform", "Beta", "Gamma"]:
-        # Check if the number of parameters is not 2
-        if len(DISTRIBUTION_PARAMS) != 2:
-            raise ValueError(f"{DISTRIBUTION} distribution must have 2 parameters")
+    if distribution in ["Normal", "LogNormal", "Uniform", "Beta", "Gamma"]:
+        if len(distribution_params) != 2:
+            raise ValueError(
+                f"{distribution} distribution must have 2 parameters")
 
     # If all checks pass, return None
     return None
@@ -158,11 +178,11 @@ N_FEATURES = len(MONTE_CARLO_PYPSA_FEATURES)# only counts features when specifie
 SAMPLES = MONTE_CARLO_OPTIONS.get("samples")   # What is the optimal sampling? Probably depend on amount of features
 SAMPLING_STRATEGY = MONTE_CARLO_OPTIONS.get("sampling_strategy")
 DISTRIBUTION = MONTE_CARLO_OPTIONS.get("distribution") # Change the distribution var to title case
-DISTRIBUTION_PARAMS = MONTE_CARLO_OPTIONS.get("distribution_params") # Change the distribution var to title case
+DISTRIBUTION_PARAMS = MONTE_CARLO_OPTIONS.get("distribution_params")
 
 ### PARAMETERS VALIDATION
 # validates the parameters supplied from config file
-validate_parameters(SAMPLING_STRATEGY, DISTRIBUTION, DISTRIBUTION_PARAMS)
+validate_parameters(SAMPLING_STRATEGY, SAMPLES, DISTRIBUTION, DISTRIBUTION_PARAMS)
 
 ###
 ### SCENARIO CREATION / SAMPLING STRATEGY
@@ -172,13 +192,13 @@ if SAMPLING_STRATEGY=="pydoe2":
 if SAMPLING_STRATEGY=="scipy":
     lh = monte_carlo_sampling_scipy(N_FEATURES, SAMPLES, centered=False, strength=2, optimization=None, seed=42)
 if SAMPLING_STRATEGY=="chaospy":
-    lh = monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION_PARAMS, rule="latin_hypercube", seed=42)   
+    lh = monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION_PARAMS, rule="latin_hypercube", seed=42)
 
 
 ###
 ### SCENARIO ITERATION
 ###
-from scipy.stats import qmc 
+from scipy.stats import qmc
 
 network = pypsa.examples.ac_dc_meshed(from_master=True)
 
@@ -197,7 +217,7 @@ for i in range(Nruns):
         # Example: n.loads_t.p_set = network.loads_t.p_set = .loads_t.p_set * lh[0,0] * (1.3-0.8)
         exec(f"n.{k} = network.{k} * {lh_scaled[i,j]}")
         print(f"Scaled n.{k} by factor {lh_scaled[i,j]} in the {i} scenario")
-        j = j + 1 
+        j = j + 1
 
     # run optimization
     n.lopf(pyomo=False)
@@ -208,4 +228,3 @@ for i in range(Nruns):
     file_path = os.path.join(directory_path, f"result_{i}.nc")
     n.export_to_netcdf(file_path)
     print(f"Run {i}. Load_sum: {n.loads_t.p_set.sum().sum()} MW ")
-

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -44,12 +44,12 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION
     from sklearn.preprocessing import MinMaxScaler
 
     params = tuple(DISTRIBUTION_PARAMS)
-    # Generate a Nfeatures-dimensional latin hypercube varying between 0 and 1:
+    # generate a Nfeatures-dimensional latin hypercube varying between 0 and 1:
     N_FEATURES = f"chaospy.{DISTRIBUTION}{params}, "*N_FEATURES
     cube = eval(f"chaospy.J({N_FEATURES})")  # writes Nfeatures times the chaospy.uniform... command)
     lh = cube.sample(SAMPLES, rule=rule, seed=seed).T
 
-    # To check the discrepancy of the samples, the values needs to be from 0-1
+    # to check the discrepancy of the samples, the values needs to be from 0-1
     mm = MinMaxScaler(feature_range=(0,1), clip=True)
     lh = mm.fit_transform(lh)
 
@@ -129,7 +129,7 @@ def validate_parameters(sampling_strategy: str, samples: int,
             f"Unsupported Distribution : {distribution}. Choose from {valid_distribution}"
         )
 
-    # Special case handling for Triangle distribution
+    # special case handling for Triangle distribution
     if distribution == "Triangle":
         if len(distribution_params) == 2:
             print(
@@ -142,21 +142,18 @@ def validate_parameters(sampling_strategy: str, samples: int,
                 f"{distribution} distribution has to be 3 parameters in the order of [lower_bound, mid_range, upper_bound]"
             )
 
-    # Handling having 0 as values in Beta and Gamma
+    # handling having 0 as values in Beta and Gamma
     if distribution in ["Beta", "Gamma"]:
-        # Check if any parameter is less than or equal to 0
         if np.min(distribution_params) <= 0:
             raise ValueError(
                 f"{distribution} distribution cannot have values lower than zero in parameters"
             )
 
-    # Handling cases of less than or greater than 2 parameters for Normal, LogNormal, Uniform, Beta, and Gamma
     if distribution in ["Normal", "LogNormal", "Uniform", "Beta", "Gamma"]:
         if len(distribution_params) != 2:
             raise ValueError(
                 f"{distribution} distribution must have 2 parameters")
 
-    # If all checks pass, return None
     return None
 
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -52,10 +52,8 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION
     if DISTRIBUTION == "Uniform":
         pass
     elif DISTRIBUTION in ["Normal", "LogNormal", "Triangle", "Beta", "Gamma"]:
-        mm = MinMaxScaler(feature_range=(0,1.))
+        mm = MinMaxScaler(feature_range=(0,1), clip=True)
         lh = mm.fit_transform(lh)
-        print(lh.max())
-        print(lh.min())
     else:
         raise ValueError(f"Distribution '{DISTRIBUTION}' not available. Please pick a valid one from possible options: 'Uniform', 'Normal', 'LogNormal', 'Triangle', 'Beta', 'Gamma'")
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -42,6 +42,27 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION
     import chaospy
     from scipy.stats import qmc 
     from sklearn.preprocessing import MinMaxScaler
+
+    if DISTRIBUTION == "Triangle":
+        if len(DISTRIBUTION_PARAMS) == 2 and len(DISTRIBUTION_PARAMS) != 3:
+            print(f"{DISTRIBUTION} distribution has to be 3 parameters in the order of [lower_bound, mid_range, upper_bound]")
+            mid = np.mean(DISTRIBUTION_PARAMS)
+            DISTRIBUTION_PARAMS.insert(1, mid) # insert the mean into the middle
+        else:
+            # if values is less than 2 or greater than 3
+            raise ValueError(f"{DISTRIBUTION} distribution has to be 3 parameters in the order of [lower_bound, mid_range, upper_bound]")
+
+    # handling having 0 as values in Beta and Gamma            
+    if DISTRIBUTION in ["Beta", "Gamma"]:
+        if np.min(DISTRIBUTION_PARAMS) <= 0:
+            raise ValueError(f"{DISTRIBUTION} distribution cannot have values lower than zero in parameters")
+
+    # handling cases of less than or greater than 2 parameters for Normal, LogNormal, Uniform, Beta and Gamma
+    if DISTRIBUTION in ["Normal", "LogNormal", "Uniform", "Beta", "Gamma"]:
+        if len(DISTRIBUTION_PARAMS) != 2:
+            raise ValueError(f"{DISTRIBUTION} distribution must have 2 parameters")
+
+
     params = tuple(DISTRIBUTION_PARAMS)
     # Generate a Nfeatures-dimensional latin hypercube varying between 0 and 1:
     N_FEATURES = f"chaospy.{DISTRIBUTION}{params}, "*N_FEATURES

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -84,7 +84,7 @@ def monte_carlo_sampling_scipy(N_FEATURES, SAMPLES, centered=False, strength=2, 
     return lh
 
 
-def validate_parameters(DISTRIBUTION, DISTRIBUTION_PARAMS):
+def validate_parameters(SAMPLING_STRATEGY, DISTRIBUTION, DISTRIBUTION_PARAMS):
     """
     Validates the parameters for a given probability distribution.
 
@@ -98,12 +98,16 @@ def validate_parameters(DISTRIBUTION, DISTRIBUTION_PARAMS):
     - ValueError: If the parameters are invalid for the specified distribution.
     """
 
-    # List of valid distribution types
+    valid_strategy = ["chaospy", "scipy", "pydoe2"]
     valid_distribution = ["Uniform", "Normal", "LogNormal", "Triangle", "Beta", "Gamma"]
+
+    # Check if the sampling strategy is valid
+    if SAMPLING_STRATEGY not in valid_strategy:
+        raise ValueError(f" Invalid sampling strategy: {SAMPLING_STRATEGY}")
 
     # Check if the specified distribution is in the list of valid distributions
     if DISTRIBUTION not in valid_distribution:
-        raise ValueError(f"Distribution '{DISTRIBUTION}' not available. Please pick a valid one from possible options: {valid_distribution}")
+        raise ValueError(f"Unsupported Distribution : {DISTRIBUTION}")
 
     # Check special case for Triangle distribution
     if DISTRIBUTION == "Triangle" and len(DISTRIBUTION_PARAMS) == 2:
@@ -158,7 +162,7 @@ DISTRIBUTION_PARAMS = MONTE_CARLO_OPTIONS.get("distribution_params") # Change th
 
 ### PARAMETERS VALIDATION
 # validates the parameters supplied from config file
-validate_parameters(DISTRIBUTION, DISTRIBUTION_PARAMS)
+validate_parameters(SAMPLING_STRATEGY, DISTRIBUTION, DISTRIBUTION_PARAMS)
 
 ###
 ### SCENARIO CREATION / SAMPLING STRATEGY

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -152,7 +152,9 @@ for i in range(Nruns):
     n.lopf(pyomo=False)
     # save each optimization result with a separate name
     n.monte_carlo = pd.DataFrame(lh_scaled).rename_axis('Nruns').add_suffix('_feature')
-    path = os.path.join(os.getcwd(), f"results{i}.nc")
-    n.export_to_netcdf(path)
+    directory_path = os.path.join(os.getcwd(), f"results")
+    os.makedirs(directory_path, exist_ok=True)
+    file_path = os.path.join(directory_path, f"result_{i}.nc")
+    n.export_to_netcdf(file_path)
     print(f"Run {i}. Load_sum: {n.loads_t.p_set.sum().sum()} MW ")
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -91,9 +91,13 @@ def validate_parameters(sampling_strategy: str, samples: int,
     Inputs from user through the config file needs to be validated before proceeding to perform monte-carlo simulations.
 
     Parameters:
-    - DISTRIBUTION: str
+    - sampling_strategy: str
+        The chosen sampling strategy from chaospy, scipy and pydoe2
+    - samples: int
+        The number of samples to generate for the simulation
+    - distribution: str
         The name of the probability distribution.
-    - DISTRIBUTION_PARAMS: list
+    - distribution_params: list
         The parameters associated with the probability distribution.
 
     Raises:

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -31,7 +31,7 @@ def monte_carlo_sampling_pydoe2(N_FEATURES, SAMPLES, criterion=None, iteration=N
     return lh
 
 
-def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, rule="latin_hypercube", seed=42):
+def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION_PARAMS, rule="latin_hypercube", seed=42):
     """
     Creates Latin Hypercube Sample (LHS) implementation from chaospy.
 
@@ -42,23 +42,20 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, rule="latin_
     import chaospy
     from scipy.stats import qmc 
     from sklearn.preprocessing import MinMaxScaler
-
+    params = tuple(DISTRIBUTION_PARAMS)
     # Generate a Nfeatures-dimensional latin hypercube varying between 0 and 1:
-    N_FEATURES = f"chaospy.{DISTRIBUTION}(0, 1), "*N_FEATURES
+    N_FEATURES = f"chaospy.{DISTRIBUTION}{tuple(params)}, "*N_FEATURES
     cube = eval(f"chaospy.J({N_FEATURES})")  # writes Nfeatures times the chaospy.uniform... command)
     lh = cube.sample(SAMPLES, rule=rule, seed=seed).T
 
     # rescale distribution to 0-1 if it is not a uniform distribution
     if DISTRIBUTION == "Uniform":
         pass
-    elif DISTRIBUTION == "Normal":
-        mm = MinMaxScaler()
-        lh = mm.fit_transform(lh)
-    elif DISTRIBUTION == "LogNormal":
+    elif DISTRIBUTION in ["Normal", "LogNormal", "Triangle", "Beta", "Gamma"]:
         mm = MinMaxScaler(feature_range=(0,0.99))
         lh = mm.fit_transform(lh)
     else:
-        raise ValueError(f"Distribution '{DISTRIBUTION}' not available. Please pick a valid one from possible options: 'Uniform', 'Normal'")
+        raise ValueError(f"Distribution '{DISTRIBUTION}' not available. Please pick a valid one from possible options: 'Uniform', 'Normal', 'LogNormal', 'Triangle', 'Beta', 'Gamma'")
 
     discrepancy = qmc.discrepancy(lh)
     print("Discrepancy is:", discrepancy, " more details in function documentation.")
@@ -113,6 +110,7 @@ N_FEATURES = len(MONTE_CARLO_PYPSA_FEATURES)# only counts features when specifie
 SAMPLES = MONTE_CARLO_OPTIONS.get("samples")   # What is the optimal sampling? Probably depend on amount of features
 SAMPLING_STRATEGY = MONTE_CARLO_OPTIONS.get("sampling_strategy")
 DISTRIBUTION = MONTE_CARLO_OPTIONS.get("distribution") # Change the distribution var to title case
+DISTRIBUTION_PARAMS = MONTE_CARLO_OPTIONS.get("distribution_params") # Change the distribution var to title case
 
 
 ###
@@ -123,7 +121,7 @@ if SAMPLING_STRATEGY=="pydoe2":
 if SAMPLING_STRATEGY=="scipy":
     lh = monte_carlo_sampling_scipy(N_FEATURES, SAMPLES, centered=False, strength=2, optimization=None, seed=42)
 if SAMPLING_STRATEGY=="chaospy":
-    lh = monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, rule="latin_hypercube", seed=42)   
+    lh = monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, DISTRIBUTION_PARAMS, rule="latin_hypercube", seed=42)   
 
 
 ###

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -43,7 +43,6 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, rule="latin_
     from scipy.stats import qmc 
     from sklearn.preprocessing import MinMaxScaler
 
-
     # Generate a Nfeatures-dimensional latin hypercube varying between 0 and 1:
     N_FEATURES = f"chaospy.{DISTRIBUTION}(0, 1), "*N_FEATURES
     cube = eval(f"chaospy.J({N_FEATURES})")  # writes Nfeatures times the chaospy.uniform... command)
@@ -54,6 +53,9 @@ def monte_carlo_sampling_chaospy(N_FEATURES, SAMPLES, DISTRIBUTION, rule="latin_
         pass
     elif DISTRIBUTION == "Normal":
         mm = MinMaxScaler()
+        lh = mm.fit_transform(lh)
+    elif DISTRIBUTION == "LogNormal":
+        mm = MinMaxScaler(feature_range=(0,0.99))
         lh = mm.fit_transform(lh)
     else:
         raise ValueError(f"Distribution '{DISTRIBUTION}' not available. Please pick a valid one from possible options: 'Uniform', 'Normal'")
@@ -110,7 +112,7 @@ U_BOUNDS = [item[1] for item in MONTE_CARLO_PYPSA_FEATURES.values()]
 N_FEATURES = len(MONTE_CARLO_PYPSA_FEATURES)# only counts features when specified in config
 SAMPLES = MONTE_CARLO_OPTIONS.get("samples")   # What is the optimal sampling? Probably depend on amount of features
 SAMPLING_STRATEGY = MONTE_CARLO_OPTIONS.get("sampling_strategy")
-DISTRIBUTION = MONTE_CARLO_OPTIONS.get("distribution").title() # Change the distribution var to title case
+DISTRIBUTION = MONTE_CARLO_OPTIONS.get("distribution") # Change the distribution var to title case
 
 
 ###


### PR DESCRIPTION
Included in this PR is an option to use LogNormal distribution for Monte-Carlo simulation.

There was an issue with the MinMax scaler, which was supposed to scale the samples between 0-1, but it has some overlap up to 0.0000000002 which was why I used a feature range argument. 

The option was changed for Distribution, Chaospy LogNormal uses Camel case. Applying a .title method on the string wouldnt work. 